### PR TITLE
toggle command mode with escape and have F -key as configurable key

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,11 @@
           "default": "deleteWordLeft",
           "description": "in command mode type e excute command"
         },
+        "flyKeys.command.f": {
+          "type": "string",
+          "default": "extension.flyKeys.deactiveCommandMode",
+          "description": "in command mode type e excute command"
+        },
         "flyKeys.command.g": {
           "type": "string",
           "default": "actions.find",
@@ -171,10 +176,10 @@
       {
         "key": "escape",
         "command": "extension.flyKeys.activeCommandMode",
-        "when": "editorTextFocus"
+        "when": "editorTextFocus && !extension.flyKeys.commandMode"
       },
       {
-        "key": "f",
+        "key": "escape",
         "command": "extension.flyKeys.deactiveCommandMode",
         "when": "editorTextFocus && extension.flyKeys.commandMode"
       }


### PR DESCRIPTION
This enables others (me) to configure f-key but otherwise it does the same thing as original code. With the exception that escape now toggles between insert and command mode.

closes #2 